### PR TITLE
Add the ability to sync all repositories

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,8 +67,7 @@ def server_prepare():
 
     # Configure S3 backend.
     s3_model = S3AsyncModel(cfg['model'])
-    # Include after the `sync_all_repos()` will be implemented.
-    # s3_model.sync_all_repos()
+    s3_model.sync_all_repos()
 
     # Set the controller to work with S3.
     s3_view = S3Controller.as_view('s3_view', s3_model)

--- a/config.default
+++ b/config.default
@@ -29,40 +29,55 @@
         "2.8"
       ],
       "distrs": {
-        "debian": [
-          "bullseye",
-          "buster",
-          "jessie",
-          "stretch"
-        ],
-        "el": [
-          "6",
-          "7",
-          "8"
-        ],
-        "fedora": [
-          "25",
-          "26",
-          "27",
-          "28",
-          "29",
-          "30",
-          "31",
-          "32",
-          "33"
-        ],
-        "opensuse-leap": [
-          "15.1",
-          "15.2"
-        ],
-        "ubuntu": [
-          "bionic",
-          "disco",
-          "eoan",
-          "focal",
-          "trusty",
-          "xenial"
-        ]
+        "debian": {
+          "base": "deb",
+          "versions": [
+            "bullseye",
+            "buster",
+            "jessie",
+            "stretch"
+          ]
+        },
+        "ubuntu": {
+          "base": "deb",
+          "versions": [
+            "bionic",
+            "disco",
+            "eoan",
+            "focal",
+            "trusty",
+            "xenial"
+          ]
+        },
+        "el": {
+          "base": "rpm",
+          "versions": [
+            "6",
+            "7",
+            "8"
+          ]
+        },
+        "fedora": {
+          "base": "rpm",
+          "versions": [
+            "25",
+            "26",
+            "27",
+            "28",
+            "29",
+            "30",
+            "31",
+            "32",
+            "33"
+          ]
+        },
+        "opensuse-leap": {
+          "base": "rpm",
+          "versions": [
+            "15.1",
+            "15.2"
+          ]
+        }
       }
     }
   }

--- a/s3repo/controller.py
+++ b/s3repo/controller.py
@@ -42,7 +42,7 @@ class S3Controller(MethodView):
             raise RuntimeError('Tarantool series "' + path[1] + '"" is not supported.')
         if path[2] not in supported_repos['distrs']:
             raise RuntimeError('Distribution "' + path[2] + '" is not supported.')
-        if path[3] not in supported_repos['distrs'][path[2]]:
+        if path[3] not in supported_repos['distrs'][path[2]]['versions']:
             raise RuntimeError('Distribution version "' + path[3] + '" is not supported.')
 
     @staticmethod

--- a/s3repo/controller.py
+++ b/s3repo/controller.py
@@ -8,6 +8,7 @@ from flask.views import MethodView
 
 from helpers.auth_provider import auth_provider
 from s3repo.model import ALLOWED_EXTENSIONS
+from s3repo.model import S3ModelRequestError
 from s3repo.package import Package
 
 
@@ -81,7 +82,10 @@ class S3Controller(MethodView):
 
         try:
             self.model.put_package(package)
-        except RuntimeError as err:
+        except S3ModelRequestError as err:
+            return S3Controller.response_message("Can't upload the package to S3: " +
+                str(err), 400)
+        except Exception as err:
             return S3Controller.response_message("Can't upload the package to S3: " +
                 str(err), 500)
 

--- a/s3repo/model.py
+++ b/s3repo/model.py
@@ -12,6 +12,12 @@ import boto3
 ALLOWED_EXTENSIONS = {'.rpm', '.deb', '.dsc', '.xz', '.gz'}
 
 
+class S3ModelRequestError(Exception):
+    """S3ModelRequestError - exception that is raised when trying to
+    use invalid input data when working with any S3Model.
+    """
+
+
 class S3AsyncModel:
     """S3AsyncModel - model for working with repositories
     on S3 in "Async" mode. "Async" means that it has several
@@ -109,7 +115,8 @@ class S3AsyncModel:
                     filename
                 ])
             else:
-                raise RuntimeError(file_type_err.format(filename, dist_base))
+                raise S3ModelRequestError(file_type_err.format(
+                    filename, dist_base))
         elif dist_base == 'deb':
             if re.fullmatch(r'.*\.(deb|dsc|tar\.xz|tar\.gz)', filename):
                 # https://wiki.debian.org/DebianRepository/Format
@@ -128,7 +135,8 @@ class S3AsyncModel:
                     filename
                 ])
             else:
-                raise RuntimeError(file_type_err.format(filename, dist_base))
+                raise S3ModelRequestError(file_type_err.format(
+                    filename, dist_base))
         else:
             raise RuntimeError('Unknown repository base: {0}.'.format(dist_base))
 


### PR DESCRIPTION
On the start of the service we want to make sure that all repositories are synced and have up-to-date metainformation. For this functionality the "sync_all_repos" method has been implemented.

Closes #7