### PR TITLE
Replace regexp to check the "init" case

### DIFF
--- a/tools/rws_backup.sh
+++ b/tools/rws_backup.sh
@@ -50,7 +50,7 @@ prepare_restic_repo() {
 	# Init the repository if it doesn't initialized or exit if the
 	# password is wrong.
 	local CHECK_RESULT=0
-	local NOT_INIT_ERROR="Stat: stat .*/config: no such file or directory"
+	local NOT_INIT_ERROR="Fatal: unable to open config file:"
 	CHECK_OUT=$(restic --repo "${RWS_BACKUP_DEST}" cat config 2>&1) \
 		|| CHECK_RESULT=${?}
 


### PR DESCRIPTION
Previously, the following regexp was used to check the "init" condition:
```
"Stat: stat .*/config: no such file or directory"
```
But this regexp only works if the "restic" repository is local.
(Error: "Fatal: unable to open config file: Stat: stat config: no such file or directory")
And it doesn't work when the "restic" repo is on S3.
(Error: "Fatal: unable to open config file: Stat: The specified key does not exist.")

The new regexp will work in all these cases.