### PR TITLE
Add possibility to set a unique GPG key for the modules repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ Environment variables:
   ('{"name": "password_hash"}').
 * `RWS_FORCE_SYNC` - skip malformed packages when synchronizing metainformation.
   Default: `False`.
-* `GPG_SIGN_KEY_ARMORED` - gpg key in ASCII armored format.
+* `GPG_SIGN_KEY_ARMORED` - gpg key in ASCII armored format to sign tarantool
+  repositories.
+* `GPG_MODULES_SIGN_KEY_ARMORED` - gpg key in ASCII armored format to sign
+  "modules" repository.
   Export the key in ASCII armored format:
   ```bash
   gpg --armor --export-secret-keys MYKEYID > mykeys.asc)

--- a/app.py
+++ b/app.py
@@ -49,6 +49,15 @@ def add_gpg_key(gpg_key):
     return match.group('name')
 
 
+def add_gpg_armored_key_to_list(env_name, key, updated_list):
+    """Adds the GPG armored key from the "env_name" environment variable to the
+    "updated_list" with the "key" key.
+    """
+    gpg_key_armored = os.getenv(env_name)
+    if gpg_key_armored:
+        updated_list[key] = add_gpg_key(gpg_key_armored.encode('ascii'))
+
+
 def get_bool_env(env_name, default=False):
     """Return the value of an environment variable as bool (True or False)."""
     env_val = os.getenv(env_name, '')
@@ -73,12 +82,11 @@ def update_cfg_by_env(cfg):
     env_model_settings['secret_access_key'] = os.getenv('S3_SECRET_KEY')
     env_model_settings['public_read'] = get_bool_env('S3_PUBLIC_READ', False)
     env_model_settings['force_sync'] = get_bool_env('RWS_FORCE_SYNC', False)
-    gpg_key_armored = os.getenv('GPG_SIGN_KEY_ARMORED')
+
     # GPG_SIGN_KEY_ARMORED stores GPG secret key for signing the repositories
-    # metadata. Our task is to add this key to the system and get its name.
-    if gpg_key_armored:
-        env_model_settings['gpg_sign_key'] = \
-            add_gpg_key(gpg_key_armored.encode('ascii'))
+    # metadata.
+    add_gpg_armored_key_to_list('GPG_SIGN_KEY_ARMORED', 'gpg_sign_key',
+                                env_model_settings)
 
     env_common_settings = {}
     env_common_settings['credentials'] = \

--- a/app.py
+++ b/app.py
@@ -87,6 +87,10 @@ def update_cfg_by_env(cfg):
     # metadata.
     add_gpg_armored_key_to_list('GPG_SIGN_KEY_ARMORED', 'gpg_sign_key',
                                 env_model_settings)
+    # GPG_MODULES_SIGN_KEY_ARMORED stores GPG secret key for signing the
+    # "modules" repository metadata.
+    add_gpg_armored_key_to_list('GPG_MODULES_SIGN_KEY_ARMORED',
+                                'gpg_modules_sign_key', env_model_settings)
 
     env_common_settings = {}
     env_common_settings['credentials'] = \

--- a/config.default
+++ b/config.default
@@ -6,6 +6,7 @@
         "release"
       ],
       "tarantool_series": [
+        "modules",
         "enabled",
         "1.10",
         "2.1",

--- a/s3repo/repoinfo.py
+++ b/s3repo/repoinfo.py
@@ -1,0 +1,17 @@
+"""Information about repository."""
+
+class RepoInfo:
+    """Information about repository."""
+
+    def __init__(self, path='', sign_key=''):
+        # Path to the repository.
+        self.path = path
+        # THe the GPG sign key ID that should be used to sign
+        # of the repository.
+        self.sign_key = sign_key
+
+    def __hash__(self):
+        return hash(self.path)
+
+    def __eq__(self, other):
+        return self.path == self.path


### PR DESCRIPTION
The repositories use different GPG keys to sign metainformation for "modules" and other tarantool repositories.
Let's add the ability to sign the meta information of the "modules" repository with a different key.

Closes #40