### PR TITLE
Add a method to update a repo metainformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ curl \
 {"message":"OK"}
 ```
 
+* Update repository metainformation without uploading a package.
+
+  The HTTP `POST` method is used to update repository metainformation
+  without uploading a package. URL describes a path to the repository
+  in the same format as the package upload.
+
+  Example:
+```bash
+curl \
+-u user_name:password \
+--request POST 127.0.0.1:5000/release/2.8/ubuntu/focal
+```
+
 ## Configuration
 
 The configuration is set by the environment variables and configuration file.

--- a/app.py
+++ b/app.py
@@ -142,7 +142,7 @@ def server_prepare():
     # Set the controller to work with S3.
     s3_controller = S3Controller.as_view('s3_controller', s3_model)
     app.add_url_rule('/<path:subpath>', view_func=s3_controller,
-        methods=['PUT', 'DELETE'])
+        methods=['PUT', 'POST', 'DELETE'])
 
     # Set the view to work with S3.
     s3_view = S3View.as_view('s3_view', s3_model)

--- a/s3repo/controller.py
+++ b/s3repo/controller.py
@@ -73,6 +73,26 @@ class S3Controller(MethodView):
         logging.info(msg)
         return S3Controller.response_message('OK', 201)
 
+    @auth_provider.login_required
+    def post(self, subpath):
+        """Update metainformation of the repository."""
+        try:
+            repo_annotation = RepoAnnotation(subpath, self.model.get_supported_repos())
+        except RuntimeError as err:
+            logging.warning(str(err))
+            return S3Controller.response_message(str(err), 400)
+
+        try:
+            self.model.update_repo(repo_annotation)
+        except Exception as err:
+            msg = "Can't update repository: " + str(err)
+            logging.warning(msg)
+            return S3Controller.response_message(msg, 500)
+
+        msg = "Repository (%s) set to queue for update." % (subpath)
+        logging.info(msg)
+        return S3Controller.response_message('OK', 200)
+
     def delete(self, subpath):
         """Delete the file or Package according to the "subpath" path."""
         return S3Controller.response_message('Delete has not yet been implemented.',

--- a/s3repo/model.py
+++ b/s3repo/model.py
@@ -251,12 +251,16 @@ class S3AsyncModel:
         """Upload files to one repo on S3."""
         # self.s3_settings['base_path'] can be None or '', in this case,
         # you do not need to add it to the path.
-        dist_path_list = [package.repo_kind, tarantool_series, package.dist]
+        dist_path_list = [
+            package.repo_annotation.repo_kind,
+            tarantool_series,
+            package.repo_annotation.dist
+        ]
         if self.s3_settings.get('base_path', ''):
             dist_path_list.insert(0, self.s3_settings['base_path'])
 
         dist_path = '/'.join(dist_path_list)
-        dist_base = self.get_supported_repos()['distrs'][package.dist]['base']
+        dist_base = self.get_supported_repos()['distrs'][package.repo_annotation.dist]['base']
 
         # Set the arguments of the uploaded files according to the settings.
         extra_args = {}
@@ -269,7 +273,7 @@ class S3AsyncModel:
         # but the metainformation hasn't been updated yet.
         unsync_repos_local = set()
         for filename, file in package.files.items():
-            path_list = S3AsyncModel._format_paths(dist_path, package.dist_version,
+            path_list = S3AsyncModel._format_paths(dist_path, package.repo_annotation.dist_version,
                                                    dist_base, filename, package.product)
 
             for repo_path, path in path_list:
@@ -545,10 +549,10 @@ class S3AsyncModel:
     def put_package(self, package):
         """Load the package to S3."""
         tarantool_series_to_upload = []
-        if package.tarantool_series == 'enabled':
+        if package.repo_annotation.tarantool_series == 'enabled':
             tarantool_series_to_upload = self.get_supported_repos()['enabled']
         else:
-            tarantool_series_to_upload.append(package.tarantool_series)
+            tarantool_series_to_upload.append(package.repo_annotation.tarantool_series)
 
         # Files already uploaded to S3.
         # Information from this dict is used to copy a file from

--- a/s3repo/package.py
+++ b/s3repo/package.py
@@ -4,15 +4,8 @@ class Package:
     """Description of the uploaded / downloaded package."""
 
     def __init__(self):
-        # Distribution (ubuntu, debian, fedora ...).
-        self.dist = ''
-        # Version of distribution (trusty, xenial, bionic ...).
-        self.dist_version = ''
-        # This parameter refers to the series of the tarantool
-        # (1.10, 2.5, 2.6 ...).
-        self.tarantool_series = ''
-        # Repo kind (live, release...).
-        self.repo_kind = ''
+        # Annotation of the repository.
+        self.repo_annotation = None
         # The name of the product to be used in the deb repositories.
         # Example: .../release/series-2/ubuntu/pool/focal/main/p/product_name/...
         self.product = ''

--- a/s3repo/repoinfo.py
+++ b/s3repo/repoinfo.py
@@ -15,3 +15,53 @@ class RepoInfo:
 
     def __eq__(self, other):
         return self.path == self.path
+
+
+class RepoAnnotation:
+    """Annotation of the repository.
+
+    This is a more common repository description than "RepoInfo".
+    What does it mean:
+    When I want to add something (or just update the metainformation)
+    of repository "release/1.10/el/7", in fact the three repositories
+    will be updated (x86_64, SRPMS, aarch64), but it's not interesting for
+    me. Or, when I update something in the repository "release/1.10/debian/jessie"
+    the metainformation for all existing version of the distribution
+    will be updated (bullseye, jessie, stretch, ...).
+    So, the "RepoAnnotation" describes the repository from the user's point of
+    view. And in fact, it can include more than one repository.
+    """
+
+    def __init__(self, path, supported_repos):
+        # Parse path.
+        path_list = path.split('/')
+        RepoAnnotation.check_path(path_list, supported_repos)
+
+        # Repo kind (live, release...).
+        self.repo_kind = path_list[0]
+        # This parameter refers to the series of the tarantool
+        # (1.10, 2.5, 2.6 ...).
+        self.tarantool_series = path_list[1]
+        # Distribution (ubuntu, debian, fedora ...).
+        self.dist = path_list[2]
+        # Version of distribution (trusty, xenial, bionic ...).
+        self.dist_version = path_list[3]
+
+    @staticmethod
+    def check_path(path, supported_repos):
+        """Checks if the given distribution is supported for
+        uploading packages.
+        """
+        # Correct path = repo_kind/tarantool_series/dist/dist_ver
+        # Example: live/1.10/el/7
+        if len(path) != 4:
+            raise RuntimeError('Invalid URL.')
+
+        if path[0] not in supported_repos['repo_kind']:
+            raise RuntimeError('Repo kind "' + path[0] + '" is not supported.')
+        if path[1] not in supported_repos['tarantool_series']:
+            raise RuntimeError('Tarantool series "' + path[1] + '"" is not supported.')
+        if path[2] not in supported_repos['distrs']:
+            raise RuntimeError('Distribution "' + path[2] + '" is not supported.')
+        if path[3] not in supported_repos['distrs'][path[2]]['versions']:
+            raise RuntimeError('Distribution version "' + path[3] + '" is not supported.')

--- a/s3repo/repoinfo.py
+++ b/s3repo/repoinfo.py
@@ -47,6 +47,12 @@ class RepoAnnotation:
         # Version of distribution (trusty, xenial, bionic ...).
         self.dist_version = path_list[3]
 
+    def __str__(self):
+        return '/'.join(self.repo_kind,
+                        self.tarantool_series,
+                        self.dist,
+                        self.dist_version)
+
     @staticmethod
     def check_path(path, supported_repos):
         """Checks if the given distribution is supported for


### PR DESCRIPTION
Now To update the metainformation of the repository, we can send a post request to the address that identifies the resource.
For example:
```
curl -u test:password --request POST 127.0.0.1:5000/release/2.8/ubuntu/focal
```

Supplement:
In fact, in the case of rpm based repositories will be updated repositories for all architextures including SRPM, for deb based all repositories related to this distribution.