### PR TITLE
Add option sync_on_start

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,8 +131,9 @@ def server_prepare():
 
     # Configure S3 backend.
     s3_model = S3AsyncModel(cfg['model'])
-    logging.info('Synchronizing metainformation of repositories...')
-    s3_model.sync_all_repos()
+    if cfg['common'].get('sync_on_start'):
+        logging.info('Synchronizing metainformation of repositories...')
+        s3_model.sync_all_repos()
 
     # Needed to cache static files on client for one hour.
     app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 3600

--- a/config.default
+++ b/config.default
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "sync_on_start": false
+  },
   "model": {
     "supported_repos": {
       "repo_kind": [


### PR DESCRIPTION
In fact, it is sometimes useful to synchronize all repositories at startup:
* you have some set of repositories without meta-information (with old metainformation)
* you have several small repositories running under the RWS, and it is good to update the metainformation on startup
But sometimes it is not so good:
* you have more than 100500 repositories running under the RWS (it takes a very long time to start up)
* your service restarts often (the service goes to sleep if you use free dynos on heroku)

So, it is good to be able to control this functionality.