### PR TITLE
Artembo/fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ Flask-HTTPAuth==4.2.0
 mkrepo==0.1.5
 gunicorn==20.1.0
 itsdangerous==2.0.1
+jinja2<3.1.0
+werkzeug==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask==1.1.2
 Flask-HTTPAuth==4.2.0
 mkrepo==0.1.5
 gunicorn==20.1.0
+itsdangerous==2.0.1


### PR DESCRIPTION
After jinja2 version 3.1.0 rws fails with error:
    
    ImportError: cannot import name 'escape' from 'jinja2'
    
Werkzeug fails with error:
    
    cannot import name 'BaseResponse' from 'werkzeug.wrappers'
