### PR TITLE
config: add 'series-2-gc64' to tarantool series

### DIFF
--- a/config.default
+++ b/config.default
@@ -13,6 +13,7 @@
         "modules",
         "enabled",
         "series-2",
+        "series-2-gc64",
         "1.10",
         "2.1",
         "2.2",


### PR DESCRIPTION
The new series is supposed to be used for tarantool packages where GC64
is enabled.