### PR TITLE
cd: deploy rws on push to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to Dokku
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04-self-hosted
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
+      - id: deploy
+        name: Deploy to dokku
+        uses: idoberko2/dokku-deploy-github-action@v1
+        with:
+            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+            dokku-host: ${{ secrets.DOKKU_HOST }}
+            app-name: ${{ secrets.DOKKU_APP }}
+            git-push-flags: '--force'


### PR DESCRIPTION
Added deploy.yml workflow which uses dokku-deploy-github-action.
It uses git under the hood for deploy and requires private key to
access Dokku server. It starts when master branch has changed.
'--force' flag for git is helpful when someone pushed commit manually
which is different from master.

Closes: #65