### PR TITLE
mkrepo: bump to new version 0.1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.17.5
 Flask==2.1.0
 Flask-HTTPAuth==4.6.0
-mkrepo==0.1.5
+mkrepo==0.1.7
 gunicorn==20.1.0


### PR DESCRIPTION
The new release of mkrepo is available on [PyPI](https://pypi.org/project/mkrepo/0.1.7/) and it's time to switch
to it. The new version has three major bug fixes:

* [4341b36c6ba3ef8409c4b1c2061a809c6298a040 (deb: fix parsing Ubuntu Impish (and higher) pkgs)](https://github.com/tarantool/mkrepo/commit/4341b36c6ba3ef8409c4b1c2061a809c6298a040)
* [2efa8061c721e814d21ddc273374143274d7e320 (deb: fix parsing signed *.dsc files)](https://github.com/tarantool/mkrepo/commit/2efa8061c721e814d21ddc273374143274d7e320)
* [80091b63bbfdf79c42cce17585988e57c2b3880c (rpm: fix sync of live/1.10/el/7/x86_64 repo)](https://github.com/tarantool/mkrepo/commit/80091b63bbfdf79c42cce17585988e57c2b3880c)