### PR TITLE
mkrepo: bump to new version 0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added support of RedOS 7.3.
 
+### Changed
+
+- Updated required version of `mkrepo` to 0.1.10. The new version of `mkrepo`
+  contains major bug fixes related to the processing of rpm repository metadata.
+
 ## [1.0.2] - 2022-07-22
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.17.5
 Flask==2.1.0
 Flask-HTTPAuth==4.6.0
-mkrepo==0.1.7
+mkrepo==0.1.10
 gunicorn==20.1.0


### PR DESCRIPTION
The new release of mkrepo is available on [PyPI](https://pypi.org/project/mkrepo/0.1.10/) and it's time to switch 
to it. The new version contains major bug fixes:

* [3d7c2d2b](https://github.com/tarantool/mkrepo/commit/3d7c2d2be5856b87a442767df20c8745208be722) (rpm: fix TypeError when sorting keys having None value)
* [c8ca21f7](https://github.com/tarantool/mkrepo/commit/c8ca21f7a7a1b99cdccece9f4767782433680495) (rpm: fix xml.etree.ElementTree.ParseError issue)
* [e770a331](https://github.com/tarantool/mkrepo/commit/e770a331a18d15338e2a55e89416c52ca43aca99) (rpm: escape special characters in XML)