### PR TITLE
mkrepo: bump 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Updated required version of `mkrepo` to 1.0.0.
+  The new release of `mkrepo` contains several improvements and bug
+  fixes for handling rpm repository metainformation. The most
+  significant of these is the addition of the ability to remove
+  information about a removed package.
+
 ## [1.0.3] - 2022-09-06
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.17.5
 Flask==2.1.0
 Flask-HTTPAuth==4.6.0
-mkrepo==0.1.10
+mkrepo==1.0.0
 gunicorn==20.1.0


### PR DESCRIPTION
The new release of `mkrepo` contains several improvements and bug fixes for handling rpm repository metainformation. The most significant of these is the addition of the ability to remove information about a removed package.