### PR TITLE
Add skip .ddeb files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Now the `.ddeb` files are simply skipped and all other files in the package
+  continue to be processed. Previously, this caused fail package uploading.
+
 ## [1.0.5] - 2022-12-07
 
 ### Changed

--- a/s3repo/controller.py
+++ b/s3repo/controller.py
@@ -82,6 +82,12 @@ class S3Controller(MethodView):
         package.product = request.form.get('product', '')
         for _, file in request.files.items():
             if not S3Controller.check_filename(file.filename):
+                # Temporary trick to skip the ".ddeb" files.
+                if '.' in file.filename and \
+                        os.path.splitext(file.filename)[1] == '.ddeb':
+                    logging.warning('Skip file: ' + file.filename)
+                    continue
+
                 msg = 'Invalid filename. Allowed file extensions: ' +\
                     ', '.join(ALLOWED_EXTENSIONS)
                 logging.warning(msg)


### PR DESCRIPTION
As long as we don't process the .ddeb files, we can just skip them and process the rest of the files correctly.

Part of #13