### PR TITLE
config: rename `astralinux` to `astra`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Renamed `astralinux` to `astra`.
 - Added support of Astra Linux 1.7.
 
 ## [1.0.9] - 2023-08-31

--- a/config.default
+++ b/config.default
@@ -91,7 +91,7 @@
             "7.3"
           ]
         },
-        "astralinux": {
+        "astra": {
           "base": "deb",
           "versions": [
             "1.7"


### PR DESCRIPTION
The most widespread shortened form of Astra Linux is `astra`.