### PR TITLE
requirements: fix issue with Werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 boto3==1.17.5
+# Werkzeug must be before Flask entry because Werkzeug 3 (it's incompatible with
+# Flask 2) has been released and Flask doesn't specify this dependency correctly
+# (it says Werkzeug >= 2.0).
+Werkzeug==2.3.8
 Flask==2.1.0
 Flask-HTTPAuth==4.6.0
 mkrepo==1.0.2


### PR DESCRIPTION
Add `Werkzeug==2.3.8` entry to the requirements.txt file before `Flask==2.1.0` entry to resolve Flask dependency `Werkzeug >= 2.0`. Otherwise, Werkzeug 3 is installed that is incompatible with Flask 2.